### PR TITLE
Replaced old stock wagon appearance, added ability to replace underground belts in place

### DIFF
--- a/prototypes/entity/entity-trains.lua
+++ b/prototypes/entity/entity-trains.lua
@@ -1,10 +1,11 @@
 data:extend({
-  {
+  -- wagons
+{
     type = "cargo-wagon",
     name = "cargo-wagon-mk2",
     icon = "__FactorioExtended-Core__/graphics/icons/cargo-wagon-mk2.png",
     flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"},
-    inventory_size = 50,
+    inventory_size = 60,
     minable = {mining_time = 1, result = "cargo-wagon-mk2"},
     mined_sound = {filename = "__core__/sound/deconstruct-medium.ogg"},
     max_health = 1200,
@@ -51,23 +52,161 @@ data:extend({
     },
     back_light = rolling_stock_back_light(),
     stand_by_light = rolling_stock_stand_by_light(),
+    -- stock color is roughly RGBA 110 60 0 127
+    color = {r = 0, g = 0.43, b = 0.08, a = 0.5}, -- RGB 0 110 20 204
     pictures =
     {
-      priority = "very-low",
-      width = 285,
-      height = 218,
-      back_equals_front = true,
-      direction_count = 128,
-      filenames =
+      layers =
       {
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk2-spritesheet-1.png",
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk2-spritesheet-2.png",
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk2-spritesheet-3.png",
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk2-spritesheet-4.png"
-      },
-      line_length = 4,
-      lines_per_file = 8,
-      shift = {0.7, -0.45}
+        {
+          priority = "very-low",
+          width = 222,
+          height = 205,
+          back_equals_front = true,
+          direction_count = 128,
+          filenames =
+          {
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-1.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-2.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-3.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-4.png"
+          },
+          line_length = 4,
+          lines_per_file = 8,
+          shift = {0, -0.796875}
+        },
+        {
+          flags = { "mask" },
+          width = 196,
+          height = 174,
+          direction_count = 128,
+          back_equals_front = true,
+          apply_runtime_tint = true,
+          shift = {0, -1.125},
+          filenames =
+          {
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-mask-1.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-mask-2.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-mask-3.png"
+          },
+          line_length = 4,
+          lines_per_file = 11,
+        },
+        {
+          flags = { "compressed" },
+          width = 246,
+          height = 201,
+          back_equals_front = true,
+          draw_as_shadow = true,
+          direction_count = 128,
+          filenames =
+          {
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-1.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-2.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-3.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-4.png"
+          },
+          line_length = 4,
+          lines_per_file = 8,
+          shift = {0.8, -0.078125}
+        }
+      }
+    },
+    horizontal_doors =
+    {
+      layers =
+      {
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-end.png",
+          line_length = 1,
+          width = 220,
+          height = 33,
+          frame_count = 8,
+          shift = {0, -0.921875}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-side.png",
+          line_length = 1,
+          width = 186,
+          height = 38,
+          frame_count = 8,
+          shift = {0, -0.78125}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-side-mask.png",
+          width = 182,
+          height = 35,
+          line_length = 1,
+          frame_count = 8,
+          shift = {0, -0.828125},
+          apply_runtime_tint = true
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-top.png",
+          line_length = 1,
+          width = 184,
+          height = 28,
+          frame_count = 8,
+          shift = {0.015625, -1.125}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-top-mask.png",
+          width = 185,
+          height = 23,
+          frame_count = 8,
+          line_length = 1,
+          shift = {0.015625, -1.17188},
+          apply_runtime_tint = true
+        }
+      }
+    },
+    vertical_doors =
+    {
+      layers =
+      {
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-end.png",
+          line_length = 8,
+          width = 30,
+          height = 202,
+          frame_count = 8,
+          shift = {0, -0.84375}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-side.png",
+          line_length = 8,
+          width = 67,
+          height = 169,
+          frame_count = 8,
+          shift = {0.015625, -1.01563}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-side-mask.png",
+          line_length = 8,
+          width = 56,
+          height = 163,
+          frame_count = 8,
+          shift = {0, -1.10938},
+          apply_runtime_tint = true
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-top.png",
+          line_length = 8,
+          width = 32,
+          height = 168,
+          frame_count = 8,
+          shift = {0, -1.125}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-top-mask.png",
+          line_length = 8,
+          width = 32,
+          height = 166,
+          frame_count = 8,
+          shift = {0, -1.15625},
+          apply_runtime_tint = true
+        }
+      }
     },
 	wheels = standard_train_wheels,
     rail_category = "regular",
@@ -93,7 +232,7 @@ data:extend({
     name = "cargo-wagon-mk3",
     icon = "__FactorioExtended-Core__/graphics/icons/cargo-wagon-mk3.png",
     flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"},
-    inventory_size = 100,
+    inventory_size = 80,
     minable = {mining_time = 1, result = "cargo-wagon-mk3"},
     mined_sound = {filename = "__core__/sound/deconstruct-medium.ogg"},
     max_health = 2400,
@@ -140,23 +279,161 @@ data:extend({
     },
     back_light = rolling_stock_back_light(),
     stand_by_light = rolling_stock_stand_by_light(),
+    -- stock color is roughly RGBA 110 60 0 127
+    color = {r = 0, g = 0.08, b = 0.43, a = 0.5}, -- RGB 0 20 110 127
     pictures =
     {
-      priority = "very-low",
-      width = 285,
-      height = 218,
-      back_equals_front = true,
-      direction_count = 128,
-      filenames =
+      layers =
       {
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk3-spritesheet-1.png",
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk3-spritesheet-2.png",
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk3-spritesheet-3.png",
-        "__FactorioExtended-Core__/graphics/entity/trains/cargo-wagon-mk3-spritesheet-4.png"
-      },
-      line_length = 4,
-      lines_per_file = 8,
-      shift = {0.7, -0.45}
+        {
+          priority = "very-low",
+          width = 222,
+          height = 205,
+          back_equals_front = true,
+          direction_count = 128,
+          filenames =
+          {
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-1.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-2.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-3.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-4.png"
+          },
+          line_length = 4,
+          lines_per_file = 8,
+          shift = {0, -0.796875}
+        },
+        {
+          flags = { "mask" },
+          width = 196,
+          height = 174,
+          direction_count = 128,
+          back_equals_front = true,
+          apply_runtime_tint = true,
+          shift = {0, -1.125},
+          filenames =
+          {
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-mask-1.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-mask-2.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-mask-3.png"
+          },
+          line_length = 4,
+          lines_per_file = 11,
+        },
+        {
+          flags = { "compressed" },
+          width = 246,
+          height = 201,
+          back_equals_front = true,
+          draw_as_shadow = true,
+          direction_count = 128,
+          filenames =
+          {
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-1.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-2.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-3.png",
+            "__base__/graphics/entity/cargo-wagon/cargo-wagon-shadow-4.png"
+          },
+          line_length = 4,
+          lines_per_file = 8,
+          shift = {0.8, -0.078125}
+        }
+      }
+    },
+    horizontal_doors =
+    {
+      layers =
+      {
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-end.png",
+          line_length = 1,
+          width = 220,
+          height = 33,
+          frame_count = 8,
+          shift = {0, -0.921875}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-side.png",
+          line_length = 1,
+          width = 186,
+          height = 38,
+          frame_count = 8,
+          shift = {0, -0.78125}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-side-mask.png",
+          width = 182,
+          height = 35,
+          line_length = 1,
+          frame_count = 8,
+          shift = {0, -0.828125},
+          apply_runtime_tint = true
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-top.png",
+          line_length = 1,
+          width = 184,
+          height = 28,
+          frame_count = 8,
+          shift = {0.015625, -1.125}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-horizontal-top-mask.png",
+          width = 185,
+          height = 23,
+          frame_count = 8,
+          line_length = 1,
+          shift = {0.015625, -1.17188},
+          apply_runtime_tint = true
+        }
+      }
+    },
+    vertical_doors =
+    {
+      layers =
+      {
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-end.png",
+          line_length = 8,
+          width = 30,
+          height = 202,
+          frame_count = 8,
+          shift = {0, -0.84375}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-side.png",
+          line_length = 8,
+          width = 67,
+          height = 169,
+          frame_count = 8,
+          shift = {0.015625, -1.01563}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-side-mask.png",
+          line_length = 8,
+          width = 56,
+          height = 163,
+          frame_count = 8,
+          shift = {0, -1.10938},
+          apply_runtime_tint = true
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-top.png",
+          line_length = 8,
+          width = 32,
+          height = 168,
+          frame_count = 8,
+          shift = {0, -1.125}
+        },
+        {
+          filename = "__base__/graphics/entity/cargo-wagon/cargo-wagon-door-vertical-top-mask.png",
+          line_length = 8,
+          width = 32,
+          height = 166,
+          frame_count = 8,
+          shift = {0, -1.15625},
+          apply_runtime_tint = true
+        }
+      }
     },
 	wheels = standard_train_wheels,
     rail_category = "regular",
@@ -178,7 +455,7 @@ data:extend({
     vehicle_impact_sound =  { filename = "__base__/sound/car-wood-impact.ogg", volume = 1.0 },
   },
   
-  
+  -- locomotives
   {
     type = "locomotive",
     name = "diesel-locomotive-mk2",

--- a/prototypes/entity/entity-transport.lua
+++ b/prototypes/entity/entity-transport.lua
@@ -5,6 +5,7 @@ data.raw["storage-tank"]["storage-tank"].fast_replaceable_group="storage-tank"
 data.raw["inserter"]["long-handed-inserter"].fast_replaceable_group="inserter"
 
 data:extend({
+  --  inserters
   {
     type = "inserter",
     name = "fast-inserter-mk2",
@@ -121,7 +122,7 @@ data:extend({
       }
     }
   },
-    {
+  {
     type = "inserter",
     name = "fast-inserter-mk3",
     icon = "__FactorioExtended-Core__/graphics/icons/fast-inserter-mk3.png",
@@ -482,8 +483,8 @@ data:extend({
     circuit_wire_max_distance = 7.5,
     uses_arm_movement = "basic-inserter"
   },
-  
-  
+
+  -- pipes
   {
     type = "pipe",
     name = "pipe-mk2",
@@ -599,7 +600,7 @@ data:extend({
     }
   },
   
-  
+  -- tanks
   {
     type = "storage-tank",
     name = "storage-tank-mk2",
@@ -869,7 +870,7 @@ data:extend({
 
   },
   
-  
+  -- ground belts
   {
     type = "transport-belt",
     name = "rapid-transport-belt-mk1",
@@ -975,7 +976,7 @@ data:extend({
     circuit_wire_max_distance = transport_belt_circuit_wire_max_distance
   },
   
-  
+  -- underground belts
   {
     type = "underground-belt",
     name = "rapid-transport-belt-to-ground-mk1",
@@ -984,13 +985,15 @@ data:extend({
     minable = {hardness = 0.2, mining_time = 0.5, result = "rapid-transport-belt-to-ground-mk1"},
     max_health = 60,
     corpse = "small-remnants",
+    max_distance = 10,
     underground_sprite =
     {
       filename = "__core__/graphics/arrows/underground-lines.png",
       priority = "high",
-      width = 32,
-      height = 32,
-      x = 32
+      width = 64,
+      height = 64,
+      x = 64,
+      scale = 0.5
     },
     resistances =
     {
@@ -1010,9 +1013,8 @@ data:extend({
     starting_top = rapid_belt_mk1_starting_top,
     starting_bottom = rapid_belt_mk1_starting_bottom,
     starting_side = rapid_belt_mk1_starting_side,
-    fast_replaceable_group = "transport-belt-to-ground",
+    fast_replaceable_group = "underground-belt",
     speed = 0.125,
-	max_distance = 10,
     structure =
     {
       direction_in =
@@ -1049,13 +1051,15 @@ data:extend({
     minable = {hardness = 0.2, mining_time = 0.5, result = "rapid-transport-belt-to-ground-mk2"},
     max_health = 60,
     corpse = "small-remnants",
+    max_distance = 20,
     underground_sprite =
     {
       filename = "__core__/graphics/arrows/underground-lines.png",
       priority = "high",
-      width = 32,
-      height = 32,
-      x = 32
+      width = 64,
+      height = 64,
+      x = 64,
+      scale = 0.5
     },
     resistances =
     {
@@ -1075,9 +1079,8 @@ data:extend({
     starting_top = rapid_belt_mk2_starting_top,
     starting_bottom = rapid_belt_mk2_starting_bottom,
     starting_side = rapid_belt_mk2_starting_side,
-    fast_replaceable_group = "transport-belt-to-ground",
+    fast_replaceable_group = "underground-belt",
     speed = 0.15625,
-	max_distance = 20,
     structure =
     {
       direction_in =
@@ -1107,7 +1110,7 @@ data:extend({
     ending_patch = ending_patch_prototype
   },
   
-  
+  -- splitters
   {
     type = "splitter",
     name = "rapid-splitter-mk1",


### PR DESCRIPTION
So, made the wagons look like stock ones with the appropriate colors applied on top
and made a small rebalancing change wrt capacity, bringing mk2 to 60, and mk3 to 80.
In retrospect the mk3 should stay at 100 and mk2 brought to a state in between, to avoid item explosions when loading old saves...
